### PR TITLE
Fix some warnings deprecation

### DIFF
--- a/src/test/scala/gcd/GCDSpec.scala
+++ b/src/test/scala/gcd/GCDSpec.scala
@@ -3,8 +3,8 @@
 package gcd
 
 import chisel3._
-import chisel3.tester._
-import org.scalatest.FreeSpec
+import chiseltest._
+import org.scalatest.AnyFreeSpec
 import chisel3.experimental.BundleLiterals._
 
 /**
@@ -18,7 +18,7 @@ import chisel3.experimental.BundleLiterals._
   * sbt 'testOnly gcd.GcdDecoupledTester'
   * }}}
   */
-class GCDSpec extends FreeSpec with ChiselScalatestTester {
+class GCDSpec extends AnyFreeSpec with ChiselScalatestTester {
 
   "Gcd should calculate proper greatest common denominator" in {
     test(new DecoupledGcd(16)) { dut =>


### PR DESCRIPTION
`MultiIOModule` is deprecated, use `Module` instead.
